### PR TITLE
fix: remove refresh database class and remove test records from the database

### DIFF
--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -9,8 +9,6 @@ use Tests\TestCase;
 
 class AuthTest extends TestCase
 {
-    use RefreshDatabase;
-
     /**
      * Test if the user can login successfully
      *
@@ -23,7 +21,7 @@ class AuthTest extends TestCase
         $email = $faker->email;
         $password = $faker->password;
 
-        User::factory()->create([
+        $user = User::factory()->create([
             'email' => $email,
             'password' => bcrypt($password),
         ]);
@@ -34,6 +32,9 @@ class AuthTest extends TestCase
         ]);
 
         $response->assertStatus(200);
+
+        $user->tokens()->delete();
+        $user->delete();
     }
 
     /**
@@ -75,6 +76,9 @@ class AuthTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertJson(['email' => $email]);
+
+        $user->tokens()->delete();
+        $user->delete();
     }
 
     /**
@@ -119,6 +123,9 @@ class AuthTest extends TestCase
 
         $response->assertStatus(200);
         $this->assertNotEquals($initial_token->id, $final_token->id);
+
+        $user->tokens()->delete();
+        $user->delete();
     }
 
     /**
@@ -163,6 +170,9 @@ class AuthTest extends TestCase
 
         $tokens = $user->tokens();
         $this->assertEquals(0, $tokens->count());
+        
+        $user->tokens()->delete();
+        $user->delete();
     }
 
     /**

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -9,8 +9,6 @@ use Tests\TestCase;
 
 class UserTest extends TestCase
 {
-    use RefreshDatabase;
-
     /**
      * Test if can create a user by api route
      *
@@ -28,6 +26,7 @@ class UserTest extends TestCase
         ]);
 
         $response->assertStatus(200);
+        User::find($response->json()['id'])->delete();
     }
 
     /**
@@ -69,6 +68,9 @@ class UserTest extends TestCase
         ]);
 
         $response->assertStatus(200);
+        
+        $user->tokens()->delete();
+        $user->delete();
     }
 
     /**
@@ -117,6 +119,11 @@ class UserTest extends TestCase
             'email' => $update_user->email,
             'registration' => $update_user->registration,
         ]);
+
+        $update_user->tokens()->delete();
+        $update_user->delete();
+        $user->tokens()->delete();
+        $user->delete();
     }
 
     /**
@@ -147,6 +154,9 @@ class UserTest extends TestCase
         $this->assertDatabaseMissing('users', [
             'id' => $user->id,
         ]);
+
+        $user->tokens()->delete();
+        $user->delete();
     }
 
     /**
@@ -185,6 +195,11 @@ class UserTest extends TestCase
         $this->assertDatabaseHas('users', [
             'id' => $delete_user->id,
         ]);
+
+        $delete_user->tokens()->delete();
+        $delete_user->delete();
+        $user->tokens()->delete();
+        $user->delete();
     }
 
     /**
@@ -208,6 +223,9 @@ class UserTest extends TestCase
             'email' => $user->email,
             'registration' => $user->registration,
         ]);
+
+        $user->tokens()->delete();
+        $user->delete();
     }
 
     /**
@@ -242,6 +260,9 @@ class UserTest extends TestCase
             'email' => $user->email,
             'registration' => $user->registration,
         ]);
+
+        $user->tokens()->delete();
+        $user->delete();
     }
 
     /**
@@ -266,6 +287,7 @@ class UserTest extends TestCase
             'registration' => $user->registration,
         ]);
 
+        $user->tokens()->delete();
         $user->delete();
 
         $this->assertDatabaseMissing('users', [


### PR DESCRIPTION
Antes após rodar os testes, resetava os dados do banco.
Agora removi a classe que fazia isso e apaguei manualmente os registros que eram incluidos nos testes para nao poluir o banco com dados de teste